### PR TITLE
optional fetch hydration

### DIFF
--- a/packages/common-types/src/fetch.ts
+++ b/packages/common-types/src/fetch.ts
@@ -31,8 +31,7 @@ export interface iPagination<O = tOrderBy> {
 	 */
 	first?: number;
 	/**
-	 * JSON string
-	 * aplica a cualquiera columna
+	 * Ordenar segun columna o propiedad
 	 * ej: ["id", "asc" ], order ascendente de id
 	 * ej: ["id", "desc" ], order descendente de id
 	 */
@@ -45,6 +44,5 @@ export interface iPagination<O = tOrderBy> {
 export type tHydrate<T> = (c: T, e?: unknown) => void;
 
 export type iGetPage<T, C extends string | number = string> = (
-	hydrate: tHydrate<iPage<T, C> | null>,
 	params?: iPagination
 ) => Promise<iPage<T, C>>;

--- a/packages/components-vue/src/components/form/InputCountriesAPI.vue
+++ b/packages/components-vue/src/components/form/InputCountriesAPI.vue
@@ -5,14 +5,14 @@
 			:el="LoaderContentFetch"
 			:wrap="!states && !!countryValue"
 			:theme="theme"
-			:promise="unHydrate(getCountryStates)"
+			:promise="getCountryStates"
 			:payload="[countryValue]"
 			unwrap
 		>
 			<LoaderContentFetch
 				v-slot="citiesReq"
 				:theme="theme"
-				:promise="!!model[1] && unHydrate(getStateCities)"
+				:promise="!!model[1] && getStateCities"
 				:payload="[countryValue, model[1]]"
 				:no-loader="statesReq.loading"
 				:fallback="[]"
@@ -34,7 +34,6 @@
 
 	import type { iUseThemeProps } from "../../types/props";
 	import type { iState } from "../../types/countries";
-	import useFetch from "../../composables/fetch";
 	import useCountries from "../../composables/countries";
 
 	interface iFormInputCountriesApi extends iUseThemeProps {
@@ -52,7 +51,6 @@
 
 	const props = defineProps<iFormInputCountriesApi>();
 
-	const { unHydrate } = useFetch();
 	const { defaultCountry, getCountryStates, getStateCities } = useCountries();
 
 	const countryValue = computed(() => props.model[0] || defaultCountry || "");

--- a/packages/components-vue/src/components/form/Simple.vue
+++ b/packages/components-vue/src/components/form/Simple.vue
@@ -5,7 +5,7 @@
 			v-slot="{ content }"
 			:theme="theme"
 			:label="t('form_loading_countries')"
-			:promise="(withLocationInput || withPhoneInput) && getCountriesAndStates"
+			:promise="(withLocationInput || !!withPhoneInput) && getCountriesAndStates"
 			class="flx --flxColumn --flx-start-stretch --gap-10 --maxWidth-full"
 			:el="noForm ? 'fieldset' : 'form'"
 			:fallback="{ countries: [], states: [] }"

--- a/packages/components-vue/src/components/pagination/Content.vue
+++ b/packages/components-vue/src/components/pagination/Content.vue
@@ -36,7 +36,7 @@
 
 	import type { iUseThemeProps } from "../../types/props";
 
-	export interface iPaginationContentProps<Ti, Ci extends string | number = string>
+	export interface iPCProps<Ti, Ci extends string | number = string>
 		extends iPagination,
 			iUseThemeProps {
 		/**
@@ -63,10 +63,8 @@
 	}
 
 	/**
-	 * Menu de paginacion [PROGRESS]
+	 * Menu de paginacion
 	 * Redirecciona a la misma ruta + el query de pagina
-	 * TODO: Add conditional items per page selector
-	 * Not sure what this was supposed to mean
 	 *
 	 * @component
 	 * @example
@@ -75,7 +73,7 @@
 
 	defineOptions({ name: "PaginationContent", inheritAttrs: false });
 
-	const props = defineProps<iPaginationContentProps<T, C>>();
+	const props = defineProps<iPCProps<T, C>>();
 
 	const xamuOptions = inject<iPluginOptions>("xamu");
 	const router = getCurrentInstance()?.appContext.config.globalProperties.$router;
@@ -111,7 +109,7 @@
 
 		return newPagination;
 	});
-	const pagination = computed<iPagination | undefined>({
+	const pagination = computed<iPagination>({
 		get() {
 			if (props.withRoute) return routePagination.value;
 


### PR DESCRIPTION
Hydration should be optional and not mandatory, Ideally implementation should be not breaking but it seems impossible.

So far there have been 2 attempts. Current one while clean with the use of overloads and an additional prop is causing some side effects that I'm unable to circumvent as of the time of writing this.

The problematic component:

https://github.com/xamu-co/ui/blob/8cf907b351562aadb4dd67566b0d95bf19908c21/packages/components-vue/src/components/pagination/Content.vue#L47

E: Refactored with some breaking changes.