### PR TITLE
fix(vue): prevent swal on esc key pressed

### DIFF
--- a/packages/components-vue/src/components/table/Simple.vue
+++ b/packages/components-vue/src/components/table/Simple.vue
@@ -639,7 +639,7 @@
 		const updated = await props.updateNode?.(node);
 
 		// unfinished task
-		if (updated === undefined) {
+		if (typeof updated !== "boolean") {
 			if (Swal.isLoading()) Swal.close();
 
 			return;
@@ -677,7 +677,7 @@
 		const cloned = await props.cloneNode?.(node);
 
 		// unfinished task
-		if (cloned === undefined) {
+		if (typeof cloned !== "boolean") {
 			if (Swal.isLoading()) Swal.close();
 
 			return;
@@ -725,7 +725,7 @@
 		const deleted = await props.deleteNode?.(node);
 
 		// unfinished task
-		if (deleted === undefined) {
+		if (typeof deleted !== "boolean") {
 			if (Swal.isLoading()) Swal.close();
 
 			return;


### PR DESCRIPTION
prevent successful swal on esc key pressed when a user is updating an entity in a table modal