### PR TITLE
fix: remove unscoped schema

### DIFF
--- a/packages/nuxt/src/types.ts
+++ b/packages/nuxt/src/types.ts
@@ -30,11 +30,7 @@ export interface XamuModuleOptions extends Omit<iVuePluginOptions, "internals"> 
 
 export type Stylesheet = string | { href: string; tagPriority?: number };
 
-declare module "nuxt/schema" {
-	interface PublicRuntimeConfig {
-		xamu: XamuModuleOptions;
-	}
-}
+// Do not use unscoped schema
 declare module "@nuxt/schema" {
 	interface PublicRuntimeConfig {
 		xamu: XamuModuleOptions;


### PR DESCRIPTION
using nuxt/schema breaks runtime config inference